### PR TITLE
Update regular_expressions.py - Only sometimes 'yY'

### DIFF
--- a/part12/part12-14_regular_expressions/src/regular_expressions.py
+++ b/part12/part12-14_regular_expressions/src/regular_expressions.py
@@ -9,7 +9,7 @@ def is_dotw(my_string: str):
 
 def all_vowels(my_string: str):
     for a in my_string:
-        if re.search("[aeiouyAEIOUY]", a):
+        if re.search("[aeiouAEIOU]", a):
             continue
         else:
             return False


### PR DESCRIPTION
MOOC/TMC said this answer was not correct - specifically the all_vowels function. Removing 'y' and 'Y' from the regular expression solved the issue.